### PR TITLE
Update Mobile Developer/Performance.md

### DIFF
--- a/Technical Stack/Mobile Developer/Performance.md
+++ b/Technical Stack/Mobile Developer/Performance.md
@@ -6,7 +6,6 @@ Performance
 
 ### [Hermes](/Technical%20Stack/Mobile%20Developer/Performance.md#hermes)
 
-*   [ ] You know how to enable Hermes on Android
 *   [ ] You know profits of using Hermes
 
 [Monitoring](/Technical%20Stack/Mobile%20Developer/Performance.md#monitoring)


### PR DESCRIPTION
Removed unnecessary point since [Hermes is enabled by default](https://reactnative.dev/docs/hermes#:~:text=Hermes%20is%20used%20by%20default%20by%20React%20Native%20and%20no%20additional%20configuration%20is%20required%20to%20enable%20it.)